### PR TITLE
Feat/weaponsforge 5

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,65 @@
+name: Deploy to Development Environment
+
+# /client app - deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  lint-client:
+    name: Lint and Export client
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_BASE_PATH: ""
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - name: Use NodeJS v20.15.0
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.15.0
+      - name: Install Dependencies
+        run: |
+          cd client
+          npm install
+      - name: Lint
+        run: |
+          cd client
+          npm run lint
+      - name: Export static files
+        run: |
+          cd client
+          npm run export
+          mv out/404/index.html out/404.html
+      - name: Prepare Firebase Deployment
+        run: |
+          cd client
+          sed -i -e "s/<FIREBASE_PROJECT>/${{ secrets.FIREBASE_APP }}/g" .firebaserc
+          sed -i -e "s/<FIREBASE_HOSTING>/${{ secrets.FIREBASE_HOSTING }}/g" .firebaserc
+      - name: Archive Development Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dev-out
+          path: |
+            client/out
+            client/.firebaserc
+            client/firebase.json
+          retention-days: 3
+
+  deploy-client:
+    name: Deploy Client to Firebase Hosting
+    needs: lint-client
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dev-out
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --only hosting:dev
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,41 @@ The following dependencies are used for this project. Feel free to experiment us
    npm run dev
    ```
 
+2. Create a new page with custom modal dialog text.
+   - Create a new page component under the `/src/pages` directory.
+   - Export `getStaticProps()` function from the new page component. The function should construct and return the `title`, `background` and `paragaraphs[]` key-value pairs.
+
+      ```jsx
+       export async function getStaticProps () {
+         return {
+           props: {
+             title: "Hello, World!",
+             background: "/images/rg_inazuma2.jpg",
+             paragraphs: [
+               { id: 0, content: "Sample text 1" },
+               { id: 1, content: "Sample text 2" },
+              ...
+            ]
+          }
+        }
+      }
+      ```
+   - Import and use the `NoticePage` component into the component created from the previous step. It should receive the `title`. `backgroud` and `paragraphs` props from the `getStaticProps()` function, and pass them to the `NoticePage` component. For example:
+
+      ```jsx
+      function App ({ title, paragraphs, background }) {
+        return (
+          <NoticePage
+            title={title}
+            paragraphs={paragraphs}
+            background={background}
+            Component={LinkTo}
+          />
+        )
+      }
+      ```
+
+
 ## Deployment
 
 ### Firebase Hosting

--- a/README.md
+++ b/README.md
@@ -46,6 +46,42 @@ The following dependencies are used for this project. Feel free to experiment us
    npm run dev
    ```
 
+## Deployment
+
+### Firebase Hosting
+
+Follow these steps for manually deploying the static site to Firebase Hosting.
+
+Create the **GitHub Actions Secrets** described in the [GitHub Actions](#github-actions) section to automatically deploy the `dev` branch to Firebase Hosting on every new push or update to the `dev` branch.
+
+#### Requirements
+
+1. Firebase project with Firebase Hosting pre-configured and set-up.
+2. Firebase CLI (Firebase Admin)
+   - Installed preferrably using the `"npm install -g firebase-tools"` command.
+
+#### Steps
+
+1. Open the `firebaserc` file in the client directory.
+2. Replace the `"<FIREBASE_PROJECT_NAME>"` key with a target Firebase project.
+3. Replace the `"<FIREBASE_HOSTING_NAME_UNDER_FIREBASE_PROJECT>"` key with a target Firebase Hosting name under the `"<FIREBASE_PROJECT_NAME>"`.
+4. Build the static site.<br>
+`npm run build`
+5. Login to your Firebase account using the Firebase CLI.<br>
+`firebase login`
+6. Deploy the static site.<br>
+`firebase deploy --only hosting`
+
+## GitHub Actions
+
+Add the following GitHub Actions "Secrets" for deploying the development app to Firebase Hosting
+
+| GitHub Secret Name | Description |
+| --- | --- |
+| FIREBASE_PROJECT | Firebase project ID |
+| FIREBASE_HOSTING | Firebase Hosting name under the `FIREBASE_PROJECT` |
+| FIREBASE_TOKEN | Firebase CI token used for deploying the /client app to Firebase Hosting. This is obtained by signing-in to the firebase CLI with `"firebase login:ci"`. |
+
 ## Available Scripts
 
 ### `npm run dev`

--- a/client/.firebaserc
+++ b/client/.firebaserc
@@ -1,0 +1,15 @@
+{
+  "projects": {
+    "default": "<FIREBASE_PROJECT>"
+  },
+  "targets": {
+    "<FIREBASE_PROJECT>": {
+      "hosting": {
+        "dev": [
+          "<FIREBASE_HOSTING>"
+        ]
+      }
+    }
+  },
+  "etags": {}
+}

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -32,6 +32,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# firebase
+.firebase
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/client/firebase.json
+++ b/client/firebase.json
@@ -1,0 +1,17 @@
+{
+  "hosting": [{
+    "target": "dev",
+    "public": "out",
+    "rewrites": [
+      {
+        "source": "**/!(*.js|*.html|*.css|*.json|*.svg|*.png|*.jpg|*.jpeg)",
+        "destination": "/index.html"
+      }
+    ],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }]
+}


### PR DESCRIPTION
- Deploy the client app to Firebase Hosting on push or updates to the `dev` branch, [#5](https://github.com/weaponsforge/disable-site/issues/5)
- Add notes for creating similar pages to the home page 